### PR TITLE
Allow stacks to expand independently by axis

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.4.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 

--- a/examples/grid.py
+++ b/examples/grid.py
@@ -15,7 +15,7 @@ class Grid(Window):
                 for i in range(11):
                     Button(f"HGrid {i}")
             HSeparator()
-            with HStack(expand=False):
+            with HStack(vexpand=False, hexpand=False):
                 Button("Add")
                 Button("Remove")
             HSeparator()

--- a/examples/output.py
+++ b/examples/output.py
@@ -22,10 +22,10 @@ class OutputDemo(Window):
         self.title = "Output Demo"
         with HLayout():
             with VStack():
-                with HStack(expand=False):
+                with HStack(vexpand=False, hexpand=False):
                     LabelEntry("stdout", key="STDOUT")
                     Button("Print", key="PRINT_STDOUT")
-                with HStack(expand=False):
+                with HStack(vexpand=False, hexpand=False):
                     LabelEntry("stderr", key="STDERR")
                     Button("Print", key="PRINT_STDERR")
             with VStack():

--- a/examples/replace.py
+++ b/examples/replace.py
@@ -17,18 +17,18 @@ class Replace(ui.Window):
             ui.CheckButton(text="VLayout 1", key="vlayout_1")
             ui.CheckButton(text="VLayout 2", key="vlayout_2")
             ui.CheckButton(text="VLayout 3", key="vlayout_3")
-            with ui.VStack(expand=False):
+            with ui.VStack(vexpand=False, hexpand=False):
                 ui.CheckButton(text="VStack 1", key="vstack_1")
                 ui.CheckButton(text="VStack 2", key="vstack_2")
                 ui.CheckButton(text="VStack 3", key="vstack_3")
-            with ui.HStack(expand=False):
+            with ui.HStack(vexpand=False, hexpand=False):
                 ui.CheckButton(text="HStack 1", key="hstack_1")
                 ui.CheckButton(text="HStack 2", key="hstack_2")
                 ui.CheckButton(text="HStack 3", key="hstack_3")
-            with ui.VGrid(rows=2, expand=False):
+            with ui.VGrid(rows=2, vexpand=False, hexpand=False):
                 for i in range(8):
                     ui.CheckButton(text=f"VGrid {i}", key=f"vgrid_{i}")
-            with ui.HGrid(cols=2, expand=False):
+            with ui.HGrid(cols=2, vexpand=False, hexpand=False):
                 for i in range(8):
                     ui.CheckButton(text=f"HGrid {i}", key=f"hgrid_{i}")
 

--- a/examples/scrolled_grid.py
+++ b/examples/scrolled_grid.py
@@ -17,7 +17,7 @@ class Grid(Window):
                 for i in range(25):
                     Button(f"HGrid {i}")
             HSeparator()
-            with HStack(expand=False):
+            with HStack(vexpand=False, hexpand=False):
                 Button("Add")
                 Button("Remove")
             HSeparator()

--- a/examples/stacks_are_lists.py
+++ b/examples/stacks_are_lists.py
@@ -10,7 +10,7 @@ class Stacks(Window):
     def config(self):
         self.title = "Stacks are Lists"
         with VLayout():
-            with HStack(expand=True):
+            with HStack():
                 with VStack():
                     self.add_control_widgets()
                 VSeparator()
@@ -24,12 +24,12 @@ class Stacks(Window):
                     with HStack(key="HStack") as self.hs:
                         ...
                 VSeparator()
-                with VStack(expand=True):
+                with VStack():
                     Label("Popped").font(weight="bold", underline=True)
                     with VStack() as self.vs_popped:
                         ...
             HSeparator()
-            with HStack(expand=False):
+            with HStack(vexpand=False, hexpand=False):
                 Label("VStack:", key="vstack_count")
                 Label("HStack:", key="hstack_count")
             HSeparator()

--- a/examples/todo.py
+++ b/examples/todo.py
@@ -11,7 +11,7 @@ class ToDoWindow(ui.Window):
             with ui.VStack() as self.vs_todo:
                 # start with a new Entry widget for a new ToDo item
                 ui.Entry(key="todo_0", focus=True)
-            with ui.HStack(halign="right", expand=False):
+            with ui.HStack(vexpand=False, hexpand=False, halign="right"):
                 ui.Button("+", key="add")
 
     def setup(self):

--- a/guitk/__init__.py
+++ b/guitk/__init__.py
@@ -49,7 +49,7 @@ from .ttk_treeview import Listbox, ListBox, Treeview, TreeView
 from .widget import Widget, widget_class_factory
 from .window import Window
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __author__ = "Rhet Turnbull"
 
 __all__ = [

--- a/guitk/__main__.py
+++ b/guitk/__main__.py
@@ -103,14 +103,14 @@ class Demo(Window):
                             with VStack():
                                 Label("These RadioButtons are in a LabelFrame")
                                 with HStack():
-                                    with VStack(expand=False):
+                                    with VStack(vexpand=False, hexpand=False):
                                         RadioButton(
                                             "Option A", key="option_a", group="group1"
                                         )
                                         RadioButton(
                                             "Option B", key="option_b", group="group1"
                                         )
-                                    with VStack(expand=False):
+                                    with VStack(vexpand=False, hexpand=False):
                                         RadioButton(
                                             "Option 1", key="option_1", group="group2"
                                         )
@@ -147,7 +147,7 @@ class Demo(Window):
                             tooltip="Treeview; click on headings to sort",
                             vscrollbar=True,
                         ),
-                        with VStack(expand=False, halign="center"):
+                        with VStack(vexpand=False, hexpand=False, halign="center"):
                             Label("Classes and functions in GUITk")
                             ListBox(
                                 key="listbox",
@@ -156,7 +156,7 @@ class Demo(Window):
                                 width=160,
                                 vscrollbar=True,
                             )
-                        with VStack(expand=False, halign="center"):
+                        with VStack(vexpand=False, hexpand=False, halign="center"):
                             Label("Doc String")
                             Text(key="docstring", height=14, width=30, vscrollbar=True)
                 with HTab("Tab 2"):
@@ -169,7 +169,7 @@ class Demo(Window):
                 with HStack():
                     Output(key="output", sticky="nsew", weightx=1, weighty=1)
                     VSeparator()
-                    with VStack(valign=tk.BOTTOM, expand=False):
+                    with VStack(vexpand=False, hexpand=False, valign=tk.BOTTOM):
                         Checkbutton("Enable", key="check_enable")
                         Checkbutton("Echo", key="check_echo")
                         Button("stdout")

--- a/guitk/containers.py
+++ b/guitk/containers.py
@@ -30,7 +30,6 @@ class _Stack(_Container):
         sticky: str | None = "nsew",
         valign: VAlign | None = None,
         halign: HAlign | None = None,
-        expand: bool = True,
         vexpand: bool = True,
         hexpand: bool = True,
         distribute: bool = False,
@@ -57,8 +56,6 @@ class _Stack(_Container):
                 Defaults to None.
             halign (HAlign, optional): The horizontal alignment for the widgets in the Stack.
                 Defaults to None.
-            expand (bool, optional): Whether the Stack should expand to fill the available space.
-                Defaults to True.
             vexpand (bool, optional): Whether the Stack should expand vertically.
                 Defaults to True.
             hexpand (bool, optional): Whether the Stack should expand horizontally.
@@ -98,24 +95,19 @@ class _Stack(_Container):
             # hscrollbar=hscrollbar,
             autohide_scrollbars=autohide_scrollbars,
         )
-        self.expand = expand if (width is None or height is None) else False
-        self.vexpand = vexpand
-        self.hexpand = hexpand
+        self.vexpand = vexpand if height is None else False
+        self.hexpand = hexpand if width is None else False
         self.distribute = distribute
         self._layout_list = []
         self._layout_lol = [[]]
 
     def _create_widget(self, parent: tk.BaseWidget, window: Window, row: int, col: int):
         super()._create_widget(parent, window, row, col)
-        if self.expand:
-            if self.vexpand:
-                parent.grid_rowconfigure(row, weight=1)
-            if self.hexpand:
-                parent.grid_columnconfigure(col, weight=1)
-        if self.height:
-            parent.grid_columnconfigure(col, weight=1)
-        if self.width:
+
+        if self.vexpand:
             parent.grid_rowconfigure(row, weight=1)
+        if self.hexpand:
+            parent.grid_columnconfigure(col, weight=1)
 
     @property
     def layout(self) -> list[list[BaseWidget]]:
@@ -285,7 +277,6 @@ class VStack(_Stack):
         sticky: str | None = "nsew",
         valign: VAlign | None = None,
         halign: HAlign | None = None,
-        expand: bool = True,
         vexpand: bool = True,
         hexpand: bool = True,
         distribute: bool = False,
@@ -307,8 +298,6 @@ class VStack(_Stack):
                 Defaults to None.
             halign (HAlign, optional): The horizontal alignment for the widgets in the VStack.
                 Defaults to None.
-            expand (bool, optional): Whether the VStack should expand to fill the available space.
-                Defaults to True.
             vexpand (bool, optional): Whether the Stack should expand vertically.
                 Defaults to True.
             hexpand (bool, optional): Whether the Stack should expand horizontally.
@@ -332,7 +321,6 @@ class VStack(_Stack):
             sticky=sticky,
             valign=valign,
             halign=halign,
-            expand=expand,
             vexpand=vexpand,
             hexpand=hexpand,
             distribute=distribute,
@@ -342,7 +330,6 @@ class VStack(_Stack):
             # hscrollbar=hscrollbar,
             autohide_scrollbars=autohide_scrollbars,
         )
-        self.expand = expand if width is None else False
 
 
 class HStack(_Stack):
@@ -357,7 +344,6 @@ class HStack(_Stack):
         sticky: str | None = "nsew",
         valign: VAlign | None = None,
         halign: HAlign | None = None,
-        expand: bool = True,
         vexpand: bool = True,
         hexpand: bool = True,
         distribute: bool = False,
@@ -379,8 +365,6 @@ class HStack(_Stack):
                 Defaults to None.
             halign (HAlign, optional): The horizontal alignment for the widgets in the HStack.
                 Defaults to None.
-            expand (bool, optional): Whether the HStack should expand to fill the available space.
-                Defaults to True.
             vexpand (bool, optional): Whether the Stack should expand vertically.
                 Defaults to True.
             hexpand (bool, optional): Whether the Stack should expand horizontally.
@@ -404,7 +388,6 @@ class HStack(_Stack):
             sticky=sticky,
             valign=valign,
             halign=halign,
-            expand=expand,
             vexpand=vexpand,
             hexpand=hexpand,
             distribute=distribute,
@@ -414,7 +397,6 @@ class HStack(_Stack):
             # hscrollbar=hscrollbar,
             autohide_scrollbars=autohide_scrollbars,
         )
-        self.expand = expand if height is None else False
 
     @property
     def layout(self) -> list[list[BaseWidget]]:
@@ -467,7 +449,6 @@ class VGrid(_Stack):
         sticky: str | None = "nsew",
         valign: VAlign | None = None,
         halign: HAlign | None = None,
-        expand: bool = True,
         vexpand: bool = True,
         hexpand: bool = True,
         vspacing: PadType | None = None,
@@ -490,8 +471,6 @@ class VGrid(_Stack):
                 Defaults to None.
             halign (HAlign, optional): The horizontal alignment for the widgets in the VStack.
                 Defaults to None.
-            expand (bool, optional): Whether the VStack should expand to fill the available space.
-                Defaults to True.
             vexpand (bool, optional): Whether the Stack should expand vertically.
                 Defaults to True.
             hexpand (bool, optional): Whether the Stack should expand horizontally.
@@ -514,7 +493,6 @@ class VGrid(_Stack):
             sticky=sticky,
             valign=valign,
             halign=halign,
-            expand=expand,
             vexpand=vexpand,
             hexpand=hexpand,
             distribute=False,
@@ -524,7 +502,6 @@ class VGrid(_Stack):
             # hscrollbar=hscrollbar,
             autohide_scrollbars=autohide_scrollbars,
         )
-        self.expand = expand if width is None else False
         self.rows = rows
 
     @property
@@ -586,7 +563,6 @@ class HGrid(_Stack):
         sticky: str | None = "nsew",
         valign: VAlign | None = None,
         halign: HAlign | None = None,
-        expand: bool = True,
         vexpand: bool = True,
         hexpand: bool = True,
         vspacing: PadType | None = None,
@@ -609,8 +585,6 @@ class HGrid(_Stack):
                 Defaults to None.
             halign (HAlign, optional): The horizontal alignment for the widgets in the VStack.
                 Defaults to None.
-            expand (bool, optional): Whether the VStack should expand to fill the available space.
-                Defaults to True.
             vexpand (bool, optional): Whether the Stack should expand vertically.
                 Defaults to True.
             hexpand (bool, optional): Whether the Stack should expand horizontally.
@@ -633,7 +607,6 @@ class HGrid(_Stack):
             sticky=sticky,
             valign=valign,
             halign=halign,
-            expand=expand,
             vexpand=vexpand,
             hexpand=hexpand,
             distribute=False,
@@ -643,7 +616,6 @@ class HGrid(_Stack):
             # hscrollbar=hscrollbar,
             autohide_scrollbars=autohide_scrollbars,
         )
-        self.expand = expand if width is None else False
         self.cols = cols
 
     @property

--- a/guitk/containers.py
+++ b/guitk/containers.py
@@ -31,6 +31,8 @@ class _Stack(_Container):
         valign: VAlign | None = None,
         halign: HAlign | None = None,
         expand: bool = True,
+        vexpand: bool = True,
+        hexpand: bool = True,
         distribute: bool = False,
         vspacing: PadType | None = None,
         hspacing: PadType | None = None,
@@ -56,6 +58,10 @@ class _Stack(_Container):
             halign (HAlign, optional): The horizontal alignment for the widgets in the Stack.
                 Defaults to None.
             expand (bool, optional): Whether the Stack should expand to fill the available space.
+                Defaults to True.
+            vexpand (bool, optional): Whether the Stack should expand vertically.
+                Defaults to True.
+            hexpand (bool, optional): Whether the Stack should expand horizontally.
                 Defaults to True.
             distribute (bool, optional): Whether the Stack should distribute widgets evenly.
             vspacing (PadType, optional): Vertical spacing between widgets. Defaults to None.
@@ -93,6 +99,8 @@ class _Stack(_Container):
             autohide_scrollbars=autohide_scrollbars,
         )
         self.expand = expand if (width is None or height is None) else False
+        self.vexpand = vexpand
+        self.hexpand = hexpand
         self.distribute = distribute
         self._layout_list = []
         self._layout_lol = [[]]
@@ -100,8 +108,10 @@ class _Stack(_Container):
     def _create_widget(self, parent: tk.BaseWidget, window: Window, row: int, col: int):
         super()._create_widget(parent, window, row, col)
         if self.expand:
-            parent.grid_rowconfigure(row, weight=1)
-            parent.grid_columnconfigure(col, weight=1)
+            if self.vexpand:
+                parent.grid_rowconfigure(row, weight=1)
+            if self.hexpand:
+                parent.grid_columnconfigure(col, weight=1)
         if self.height:
             parent.grid_columnconfigure(col, weight=1)
         if self.width:
@@ -276,6 +286,8 @@ class VStack(_Stack):
         valign: VAlign | None = None,
         halign: HAlign | None = None,
         expand: bool = True,
+        vexpand: bool = True,
+        hexpand: bool = True,
         distribute: bool = False,
         vspacing: PadType | None = None,
         hspacing: PadType | None = None,
@@ -297,6 +309,10 @@ class VStack(_Stack):
                 Defaults to None.
             expand (bool, optional): Whether the VStack should expand to fill the available space.
                 Defaults to True.
+            vexpand (bool, optional): Whether the Stack should expand vertically.
+                Defaults to True.
+            hexpand (bool, optional): Whether the Stack should expand horizontally.
+                Defaults to True.
             distribute (bool, optional): Whether the VStack should distribute widgets evenly.
             vspacing (PadType, optional): Vertical spacing between widgets. Defaults to None.
             hspacing (PadType, optional): Horizontal spacing between widgets. Defaults to None.
@@ -317,6 +333,8 @@ class VStack(_Stack):
             valign=valign,
             halign=halign,
             expand=expand,
+            vexpand=vexpand,
+            hexpand=hexpand,
             distribute=distribute,
             vspacing=vspacing,
             hspacing=hspacing,
@@ -340,6 +358,8 @@ class HStack(_Stack):
         valign: VAlign | None = None,
         halign: HAlign | None = None,
         expand: bool = True,
+        vexpand: bool = True,
+        hexpand: bool = True,
         distribute: bool = False,
         vspacing: PadType | None = None,
         hspacing: PadType | None = None,
@@ -361,6 +381,10 @@ class HStack(_Stack):
                 Defaults to None.
             expand (bool, optional): Whether the HStack should expand to fill the available space.
                 Defaults to True.
+            vexpand (bool, optional): Whether the Stack should expand vertically.
+                Defaults to True.
+            hexpand (bool, optional): Whether the Stack should expand horizontally.
+                Defaults to True.
             distribute (bool, optional): Whether the HStack should distribute widgets evenly.
             vspacing (PadType, optional): Vertical spacing between widgets. Defaults to None.
             hspacing (PadType, optional): Horizontal spacing between widgets. Defaults to None.
@@ -381,6 +405,8 @@ class HStack(_Stack):
             valign=valign,
             halign=halign,
             expand=expand,
+            vexpand=vexpand,
+            hexpand=hexpand,
             distribute=distribute,
             vspacing=vspacing,
             hspacing=hspacing,
@@ -442,6 +468,8 @@ class VGrid(_Stack):
         valign: VAlign | None = None,
         halign: HAlign | None = None,
         expand: bool = True,
+        vexpand: bool = True,
+        hexpand: bool = True,
         vspacing: PadType | None = None,
         hspacing: PadType | None = None,
         vscrollbar: bool = False,
@@ -464,6 +492,10 @@ class VGrid(_Stack):
                 Defaults to None.
             expand (bool, optional): Whether the VStack should expand to fill the available space.
                 Defaults to True.
+            vexpand (bool, optional): Whether the Stack should expand vertically.
+                Defaults to True.
+            hexpand (bool, optional): Whether the Stack should expand horizontally.
+                Defaults to True.
             vspacing (PadType, optional): Vertical spacing between widgets. Defaults to None.
             hspacing (PadType, optional): Horizontal spacing between widgets. Defaults to None.
             vscrollbar (bool): Whether to include a vertical scrollbar. Defaults to False.
@@ -483,6 +515,8 @@ class VGrid(_Stack):
             valign=valign,
             halign=halign,
             expand=expand,
+            vexpand=vexpand,
+            hexpand=hexpand,
             distribute=False,
             vspacing=vspacing,
             hspacing=hspacing,
@@ -553,6 +587,8 @@ class HGrid(_Stack):
         valign: VAlign | None = None,
         halign: HAlign | None = None,
         expand: bool = True,
+        vexpand: bool = True,
+        hexpand: bool = True,
         vspacing: PadType | None = None,
         hspacing: PadType | None = None,
         vscrollbar: bool = False,
@@ -575,6 +611,10 @@ class HGrid(_Stack):
                 Defaults to None.
             expand (bool, optional): Whether the VStack should expand to fill the available space.
                 Defaults to True.
+            vexpand (bool, optional): Whether the Stack should expand vertically.
+                Defaults to True.
+            hexpand (bool, optional): Whether the Stack should expand horizontally.
+                Defaults to True.
             vspacing (PadType, optional): Vertical spacing between widgets. Defaults to None.
             hspacing (PadType, optional): Horizontal spacing between widgets. Defaults to None.
             vscrollbar (bool): Whether to include a vertical scrollbar. Defaults to False.
@@ -594,6 +634,8 @@ class HGrid(_Stack):
             valign=valign,
             halign=halign,
             expand=expand,
+            vexpand=vexpand,
+            hexpand=hexpand,
             distribute=False,
             vspacing=vspacing,
             hspacing=hspacing,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "guitk"
-version = "0.4.3"
+version = "0.4.4"
 description = "Python GUI Toolkit for Tk (guitk): simplify the layout and construction of tkinter graphical user interfaces in python."
 authors = ["Rhet Turnbull <rturnbull+git@gmail.com>"]
 license = "MIT License"


### PR DESCRIPTION
Hi there!

I was checking out this library and it's awesome! Thank you so much for making it 😄 

There are a couple things that I wished I could do but couldn't. This one in particular seemed straightforward enough to implement, so here's a PR!

---

This adds support for passing `vexpand`/`hexpand` to `*Stack`s and `*Grid`s to control the 'expansion' on each axis individually. The main use case for me was having `HStacks` in a `VLayout` that expand horizontally but not vertically so their height is always the same.

The existing behavior with `expand`/`height`/`width` remains the same, so this change is backwards compatible. But if `expand=True`, then the new parameters can be used.

Let me know if there's anything I missed 😊