### PR TITLE
Pass missing weight* arguments in Progressbar

### DIFF
--- a/guitk/ttk_progressbar.py
+++ b/guitk/ttk_progressbar.py
@@ -94,6 +94,8 @@ class Progressbar(BaseWidget):
             sticky=sticky,
             tooltip=tooltip,
             value_type=tk.DoubleVar,
+            weightx=weightx,
+            weighty=weighty,
         )
         self.widget_type = "ttk.Progressbar"
         self.key = key or "Progressbar"


### PR DESCRIPTION
Hi there again!

I was placing a `ProgressBar` in my UI and noticed that `weightx` had no effect on it. It seems like `weightx` and `weighty` were not being passed to `BaseWidget.__init__`.

Not sure if this was intentional or not, but thought I'd sent the change just in case. Let me know if this can't be changed for some reason!